### PR TITLE
VMO-1816/Entity select block config changes

### DIFF
--- a/src/domain/prompt/BasePrompt.ts
+++ b/src/domain/prompt/BasePrompt.ts
@@ -56,7 +56,10 @@ export abstract class BasePrompt<PromptConfigType extends IPromptConfig<PromptCo
     public interactionId: string,
     public runner: IFlowRunner
   ) {
-
+    // Needs to default to whatever isResponseRequired, for cases where no selection/value is a valid state
+    if (!config.isResponseRequired) {
+      this.value = null
+    }
     // todo: add canPerformEarlyExit() behaviour
   }
 

--- a/src/domain/prompt/ISelectOnePromptConfig.ts
+++ b/src/domain/prompt/ISelectOnePromptConfig.ts
@@ -27,6 +27,7 @@ import {IPromptConfig, KnownPrompts} from './IPrompt'
 export interface ISelectOnePromptConfig extends IPromptConfig<IChoice['key'] | null> {
   kind: KnownPrompts.SelectOne,
   choices: IChoice[],
+  emptyChoicesMessage?: string,
 }
 
 export interface IChoice {

--- a/src/domain/prompt/SelectOnePrompt.ts
+++ b/src/domain/prompt/SelectOnePrompt.ts
@@ -27,11 +27,11 @@ import {ISelectOnePromptConfig} from './ISelectOnePromptConfig'
  * {@link IContact}.
  */
 export class SelectOnePrompt extends BasePrompt<ISelectOnePromptConfig & IBasePromptConfig> {
-  validate(choiceKey: string) {
+
+  validate(choiceKey?: string | null) {
     const {isResponseRequired, choices} = this.config
 
-    if (isResponseRequired
-      && choices.find(({key}) => key === choiceKey) == null) {
+    if (isResponseRequired && choices.find(({key}) => key === choiceKey) == null) {
       throw new ValidationException('Value provided must be in list of choices')
     }
 


### PR DESCRIPTION
- made BasePrompt initialize value to null if no response is required.
- Added emptyChoicesMessage to ISelectOnePromptConfig.ts and added null to SelectOnePrompt.validate()