### PR TITLE
Vmo 2458 add ability to backtracking peek left along with block accessor on BasePrompt

### DIFF
--- a/src/__tests__/behaviours/BasicBacktrackingBehaviour.spec.ts
+++ b/src/__tests__/behaviours/BasicBacktrackingBehaviour.spec.ts
@@ -7,7 +7,7 @@ import {IBasePromptConfig, IPromptConfig} from '../../index'
 import {NON_INTERACTIVE_BLOCK_TYPES} from '../../domain/FlowRunner'
 import IPrompt from '../../domain/prompt/IPrompt'
 import IBlock from '../../flow-spec/IBlock'
-import BasicBacktrackingBehaviour from '../../domain/behaviours/BacktrackingBehaviour/BasicBacktrackingBehaviour'
+import BasicBacktrackingBehaviour, {PeekDirection} from '../../domain/behaviours/BacktrackingBehaviour/BasicBacktrackingBehaviour'
 
 
 describe('BasicBacktrackingBehaviour', () => {
@@ -68,7 +68,7 @@ describe('BasicBacktrackingBehaviour', () => {
       const block: IBlock = backtracking.context.flows[0].blocks[0]
       const interaction: IBlockInteraction = first(backtracking.context.interactions)!
 
-      const cursor = await backtracking.peek(0, backtracking.context, true)
+      const cursor = await backtracking.peek(0, backtracking.context, PeekDirection.FROM_LEFT)
       expect(backtracking.promptBuilder.buildPromptFor).toHaveBeenCalledWith(block, interaction)
       expect(interaction.value).toBeTruthy()
       expect(cursor.prompt).toBe(virtualPrompt)

--- a/src/__tests__/behaviours/BasicBacktrackingBehaviour.spec.ts
+++ b/src/__tests__/behaviours/BasicBacktrackingBehaviour.spec.ts
@@ -59,6 +59,22 @@ describe('BasicBacktrackingBehaviour', () => {
       expect(cursor.prompt.value).toEqual(interaction.value)
     })
 
+    it('should return prompt for first interaction when default args provided and `fromLeft` is truthy', async () => {
+      // set up for fromLeft // reverse traversal
+      const firstInteraction = backtracking.context.interactions[0]
+      backtracking.context.interactions[0] = backtracking.context.interactions[5]
+      backtracking.context.interactions[5] = firstInteraction
+
+      const block: IBlock = backtracking.context.flows[0].blocks[0]
+      const interaction: IBlockInteraction = first(backtracking.context.interactions)!
+
+      const cursor = await backtracking.peek(0, backtracking.context, true)
+      expect(backtracking.promptBuilder.buildPromptFor).toHaveBeenCalledWith(block, interaction)
+      expect(interaction.value).toBeTruthy()
+      expect(cursor.prompt).toBe(virtualPrompt)
+      expect(cursor.prompt.value).toEqual(interaction.value)
+    })
+
     it('should use interaction `steps` places from the end of interactions list', async () => {
       const block: IBlock = backtracking.context.flows[0].blocks[0]
       const interaction: IBlockInteraction = backtracking.context.interactions[2]

--- a/src/__tests__/behaviours/BasicBacktrackingBehaviour.spec.ts
+++ b/src/__tests__/behaviours/BasicBacktrackingBehaviour.spec.ts
@@ -68,7 +68,7 @@ describe('BasicBacktrackingBehaviour', () => {
       const block: IBlock = backtracking.context.flows[0].blocks[0]
       const interaction: IBlockInteraction = first(backtracking.context.interactions)!
 
-      const cursor = await backtracking.peek(0, backtracking.context, PeekDirection.FROM_LEFT)
+      const cursor = await backtracking.peek(0, backtracking.context, PeekDirection.RIGHT)
       expect(backtracking.promptBuilder.buildPromptFor).toHaveBeenCalledWith(block, interaction)
       expect(interaction.value).toBeTruthy()
       expect(cursor.prompt).toBe(virtualPrompt)

--- a/src/__tests__/prompt/BasePrompt.spec.ts
+++ b/src/__tests__/prompt/BasePrompt.spec.ts
@@ -1,5 +1,6 @@
 import MessagePrompt from '../../domain/prompt/MessagePrompt'
 import {
+  findInteractionWith,
   IBasePromptConfig,
   IContextInputRequired,
   IMessagePromptConfig,
@@ -22,7 +23,7 @@ describe('BasePrompt', () => {
   describe('default state', () => {
     describe('error', () => {
       it('should default its error state to empty to simply UI rendering', async () => {
-        let config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
+        const config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
         const
           ctx = dataset.contexts[1] as IContextInputRequired,
           runner = new FlowRunner(ctx),
@@ -38,7 +39,7 @@ describe('BasePrompt', () => {
 
   describe('fulfill', () => {
     it('should set provided value onto itself', async () => {
-      let config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
+      const config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
       const
         ctx = dataset.contexts[1] as IContextInputRequired,
         runner = new FlowRunner(ctx),
@@ -56,7 +57,7 @@ describe('BasePrompt', () => {
     })
 
     it('should return result of calling run on its runner', async () => {
-      let config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
+      const config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
       const
         ctx = dataset.contexts[1] as IContextInputRequired,
         runner = new FlowRunner(ctx),
@@ -71,6 +72,41 @@ describe('BasePrompt', () => {
 
       const cursor = await prompt.fulfill(null)
       expect(cursor).toBe(richCursor)
+    })
+  })
+  
+  describe('block', () => {
+    it('should return block when block exists on runner', () => {
+      const config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
+      const
+        ctx = dataset.contexts[1] as IContextInputRequired,
+        runner = new FlowRunner(ctx),
+        prompt = new MessagePrompt(
+          config as IMessagePromptConfig & IBasePromptConfig,
+          '09894745-38ba-456f-aab4-720b7d09d5b3', // first interaction
+          runner)
+
+      expect(prompt.block).toBe(ctx.flows[1].blocks[0])
+    })
+    
+    it.skip('should return block on flow specified by interaction and not necessarily active flow', () => {
+      // first flow, first (+ only) block: 42e635ea-bc57-4c68-a8d6-20f648968bec
+      // first flow: 957a8923-428a-420f-8053-d23927e0eea0
+      
+    })
+    
+    it('should return null when block absent on runner (and not raise)', () => {
+      const config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
+      const
+        ctx = dataset.contexts[1] as IContextInputRequired,
+        runner = new FlowRunner(ctx),
+        prompt = new MessagePrompt(
+          config as IMessagePromptConfig & IBasePromptConfig,
+          '09894745-38ba-456f-aab4-720b7d09d5b3', // first interaction
+          runner)
+      
+      findInteractionWith('09894745-38ba-456f-aab4-720b7d09d5b3', ctx)!.blockId = 'some-absent-block'
+      expect(prompt.block).toBeUndefined()
     })
   })
 })

--- a/src/__tests__/prompt/BasePrompt.spec.ts
+++ b/src/__tests__/prompt/BasePrompt.spec.ts
@@ -78,12 +78,13 @@ describe('BasePrompt', () => {
   describe('block', () => {
     it('should return block when block exists on runner', () => {
       const config: IPromptConfig<any> & IBasePromptConfig = dataset._prompts[0]
+      const firstInteractionId = '09894745-38ba-456f-aab4-720b7d09d5b3'
       const
         ctx = dataset.contexts[1] as IContextInputRequired,
         runner = new FlowRunner(ctx),
         prompt = new MessagePrompt(
           config as IMessagePromptConfig & IBasePromptConfig,
-          '09894745-38ba-456f-aab4-720b7d09d5b3', // first interaction
+          firstInteractionId,
           runner)
 
       expect(prompt.block).toBe(ctx.flows[1].blocks[0])

--- a/src/domain/behaviours/BacktrackingBehaviour/BasicBacktrackingBehaviour.ts
+++ b/src/domain/behaviours/BacktrackingBehaviour/BasicBacktrackingBehaviour.ts
@@ -31,8 +31,8 @@ import FlowRunner, {IFlowNavigator, IPromptBuilder, NON_INTERACTIVE_BLOCK_TYPES}
 import {findBlockWith} from '../../..'
 
 export enum PeekDirection {
-  FROM_LEFT = 'FROM_LEFT',
-  FROM_RIGHT = 'FROM_RIGHT',
+  RIGHT = 'RIGHT',
+  LEFT = 'LEFT',
 }
 
 /**
@@ -114,10 +114,10 @@ export class BasicBacktrackingBehaviour implements IBackTrackingBehaviour {
       context)
   }
   
-  _findInteractiveInteractionAt(steps = 0, context: IContext = this.context, direction = PeekDirection.FROM_RIGHT): IBlockInteraction {
+  _findInteractiveInteractionAt(steps = 0, context: IContext = this.context, direction = PeekDirection.LEFT): IBlockInteraction {
     const _find = {
-      [PeekDirection.FROM_RIGHT]: findLast,
-      [PeekDirection.FROM_LEFT]: find,
+      [PeekDirection.RIGHT]: find,
+      [PeekDirection.LEFT]: findLast,
     }[direction]
     
     if (_find == null) {
@@ -136,7 +136,7 @@ export class BasicBacktrackingBehaviour implements IBackTrackingBehaviour {
     return intx
   }
 
-  async peek(steps = 0, context: IContext = this.context, direction = PeekDirection.FROM_RIGHT): Promise<IRichCursorInputRequired> {
+  async peek(steps = 0, context: IContext = this.context, direction = PeekDirection.LEFT): Promise<IRichCursorInputRequired> {
     const intx = this._findInteractiveInteractionAt(steps, context, direction)
     const block = findBlockWith(
       intx.blockId,


### PR DESCRIPTION
Add ability to peek from left or from right depending on argument. 
This changeset simply abstracts the search and toggles between lodash `find()`/`findLast()`. 