### PR TITLE
feature/FixContactGroupConstructors

### DIFF
--- a/src/flow-spec/Group.ts
+++ b/src/flow-spec/Group.ts
@@ -1,7 +1,13 @@
 import {createFormattedDate, IContactGroup, IGroup, isGroup} from '..'
 
 export class Group implements IGroup {
-  constructor(public group_key: string, public label?: string) {}
+  group_key: string
+  label?: string
+
+  constructor(group_key: string, label?: string) {
+    this.group_key = group_key
+    this.label = label
+  }
 
   get __value__(): string {
     return this.group_key
@@ -10,19 +16,17 @@ export class Group implements IGroup {
 
 export class ContactGroup extends Group implements IContactGroup {
   updated_at: string
-  deleted_at?: string | undefined
+  deleted_at?: string
 
-  constructor(group: IGroup)
-  constructor(group_key: string, label: string, updated_at: string, deleted_at?: string)
-  constructor(group_key: string, updated_at: string, deleted_at?: string)
-  constructor(groupKeyOrGroup: string | IGroup, label?: string, updated_at?: string, deleted_at?: string) {
+  constructor(group: IGroup, updated_at?: string, deleted_at?: string, label?: string)
+  constructor(group_key: string, updated_at?: string, deleted_at?: string, label?: string)
+  constructor(groupKeyOrGroup: string | IGroup, updated_at: string = createFormattedDate(), deleted_at?: string, label?: string) {
     if (isGroup(groupKeyOrGroup)) {
       super(groupKeyOrGroup.group_key, groupKeyOrGroup.label)
-      this.updated_at = createFormattedDate()
     } else {
       super(groupKeyOrGroup, label)
     }
-    this.updated_at = updated_at ?? createFormattedDate()
+    this.updated_at = updated_at
     if (deleted_at != null) {
       this.deleted_at = deleted_at
     }


### PR DESCRIPTION
Resolved issues where constructors of ContactGroup did not align, and label was being used incorrectly for other fields.