### PR TITLE
Bugfix/vmo 6431/block name regex

### DIFF
--- a/dist/resources/validationSchema/1.0.0-rc4/IAdvancedSelectOneBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/IAdvancedSelectOneBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/ICaseBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/ICaseBlock.json
@@ -13,7 +13,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/ILocationResponseBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/ILocationResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/ILogBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/ILogBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/IMessageBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/IMessageBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/INumericResponseBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/INumericResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/IOpenResponseBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/IOpenResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/IOutputBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/IOutputBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/IPhotoResponseBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/IPhotoResponseBlock.json
@@ -13,7 +13,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/IPrintBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/IPrintBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/IReadBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/IReadBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/IRunFlowBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/IRunFlowBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/ISelectManyResponseBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/ISelectManyResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/ISelectOneResponseBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/ISelectOneResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/ISetContactPropertyBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/ISetContactPropertyBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/ISetGroupMembershipBlock.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/ISetGroupMembershipBlock.json
@@ -13,7 +13,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/1.0.0-rc4/flowSpecJsonSchema.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/flowSpecJsonSchema.json
@@ -23,7 +23,7 @@
         },
         "name": {
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$",
+          "pattern": "^[a-zA-Z_]\\w+$",
           "type": "string"
         },
         "semantic_label": {

--- a/dist/resources/validationSchema/current/IAdvancedSelectOneBlock.json
+++ b/dist/resources/validationSchema/current/IAdvancedSelectOneBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/ICaseBlock.json
+++ b/dist/resources/validationSchema/current/ICaseBlock.json
@@ -13,7 +13,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/ILocationResponseBlock.json
+++ b/dist/resources/validationSchema/current/ILocationResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/ILogBlock.json
+++ b/dist/resources/validationSchema/current/ILogBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/IMessageBlock.json
+++ b/dist/resources/validationSchema/current/IMessageBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/INumericResponseBlock.json
+++ b/dist/resources/validationSchema/current/INumericResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/IOpenResponseBlock.json
+++ b/dist/resources/validationSchema/current/IOpenResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/IOutputBlock.json
+++ b/dist/resources/validationSchema/current/IOutputBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/IPhotoResponseBlock.json
+++ b/dist/resources/validationSchema/current/IPhotoResponseBlock.json
@@ -13,7 +13,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/IPrintBlock.json
+++ b/dist/resources/validationSchema/current/IPrintBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/IReadBlock.json
+++ b/dist/resources/validationSchema/current/IReadBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/IRunFlowBlock.json
+++ b/dist/resources/validationSchema/current/IRunFlowBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/ISelectManyResponseBlock.json
+++ b/dist/resources/validationSchema/current/ISelectManyResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/ISelectOneResponseBlock.json
+++ b/dist/resources/validationSchema/current/ISelectOneResponseBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/ISetContactPropertyBlock.json
+++ b/dist/resources/validationSchema/current/ISetContactPropertyBlock.json
@@ -14,7 +14,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/ISetGroupMembershipBlock.json
+++ b/dist/resources/validationSchema/current/ISetGroupMembershipBlock.json
@@ -13,7 +13,7 @@
         "name": {
           "type": "string",
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$"
+          "pattern": "^[a-zA-Z_]\\w+$"
         },
         "label": {
           "type": "string",

--- a/dist/resources/validationSchema/current/flowSpecJsonSchema.json
+++ b/dist/resources/validationSchema/current/flowSpecJsonSchema.json
@@ -23,7 +23,7 @@
         },
         "name": {
           "description": "A human-readable \"variable name\" for this block. This must be restricted to word characters so that it can be used as a variable name in expressions. When blocks write results output, they write to a variable corresponding the name of the block.",
-          "pattern": "^[a-zA-Z_]\\w*$",
+          "pattern": "^[a-zA-Z_]\\w+$",
           "type": "string"
         },
         "semantic_label": {

--- a/src/flow-spec/IBlock.ts
+++ b/src/flow-spec/IBlock.ts
@@ -71,7 +71,7 @@ export interface IBlock<BLOCK_CONFIG = IBlockConfig> {
    * This must be restricted to word characters so that it can be used as a variable name in expressions.
    * When blocks write results output, they write to a variable corresponding the name of the block.
    *
-   * @pattern ^[a-zA-Z_]\w*$
+   * @pattern ^[a-zA-Z_]\w+$
    */
   name: string
 


### PR DESCRIPTION
Given the prior permissive regex, "" would be a valid block name.
This is undesirable since it would make referencing the block impossible. The best user experience would be to disallow such a name by requiring at least one character.