### PR TITLE
schema: allow resource values with empty strings

### DIFF
--- a/dist/flow-spec/IResource.d.ts
+++ b/dist/flow-spec/IResource.d.ts
@@ -6,7 +6,7 @@ export interface IResourceValue {
     modes: SupportedMode[];
     /**
      * Value will accept alphanumerics, white spaces, file path, expressions, conditions,
-     * @pattern ^[\w \r\n\\\/@:,.!?+*^<>=()"'-]+$
+     * @pattern ^[\w \r\n\\\/@:,.!?+*^<>=()"'-]*$
      * @format floip-expression
      */
     value: string;

--- a/dist/resources/validationSchema/1.0.0-rc4/flowSpecJsonSchema.json
+++ b/dist/resources/validationSchema/1.0.0-rc4/flowSpecJsonSchema.json
@@ -381,7 +381,7 @@
         "value": {
           "description": "Value will accept alphanumerics, white spaces, file path, expressions, conditions,",
           "format": "floip-expression",
-          "pattern": "^[\\w \\r\\n\\\\\\/@:,.!?+*^<>=()\"'-]+$",
+          "pattern": "^[\\w \\r\\n\\\\\\/@:,.!?+*^<>=()\"'-]*$",
           "type": "string"
         }
       },

--- a/dist/resources/validationSchema/current/flowSpecJsonSchema.json
+++ b/dist/resources/validationSchema/current/flowSpecJsonSchema.json
@@ -381,7 +381,7 @@
         "value": {
           "description": "Value will accept alphanumerics, white spaces, file path, expressions, conditions,",
           "format": "floip-expression",
-          "pattern": "^[\\w \\r\\n\\\\\\/@:,.!?+*^<>=()\"'-]+$",
+          "pattern": "^[\\w \\r\\n\\\\\\/@:,.!?+*^<>=()\"'-]*$",
           "type": "string"
         }
       },

--- a/src/flow-spec/IResource.ts
+++ b/src/flow-spec/IResource.ts
@@ -7,7 +7,7 @@ export interface IResourceValue {
   modes: SupportedMode[]
   /**
    * Value will accept alphanumerics, white spaces, file path, expressions, conditions,
-   * @pattern ^[\w \r\n\\\/@:,.!?+*^<>=()"'-]+$
+   * @pattern ^[\w \r\n\\\/@:,.!?+*^<>=()"'-]*$
    * @format floip-expression
    */
   value: string


### PR DESCRIPTION
https://floip.gitbook.io/flow-specification/flows#resources

ResourceValue.value is just specified as `string`
Empty strings are still valid strings.