### PR TITLE
VMO-7105 update version to allow correct semantic versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@floip/flow-runner",
-  "version": "1.0.11-rc4.15",
+  "version": "1.0.12-rc4.15",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": "git@github.com:FLOIP/flow-runner.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@floip/flow-runner",
-  "version": "1.0.0-rc4.15",
+  "version": "1.0.11-rc4.15",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "repository": "git@github.com:FLOIP/flow-runner.git",


### PR DESCRIPTION
As our npm package doesn't follow right semantic versioning, this would fix it. In fact,
- Years ago, we have defined: 1.0.1, ..., 1.0.10, 1.0.11
- But after 1.0.11, we did `1.0.0-rc2.x.y`, `1.0.0-rc3.x.y`, `1.0.0-rc4.x.y`, which would lead to an issue. Because if we consume `^1.0.0-rc4`, that would install `1.0.11` not the lastest `1.0.0-rc4.x.y`

![Screen Shot 2022-11-10 at 2 04 46 PM](https://user-images.githubusercontent.com/68745918/201198305-e0abfe00-f3f1-4a6a-b9e5-4fff49d4cd2d.png)

The solutions are:
1- unpublish all 1.0.1, ..., 1.0.10, 1.0.11 versions, but this is not allowed by npm as there already many download on those versions
2- define a new latest version `1.0.12-rc4.x.y` to refer to `version 1, rc4`, which would be the best choice